### PR TITLE
Clean up dockerfile, fix a couple of bugs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,22 +8,6 @@ MAINTAINER KBase Developer
 
 # RUN apt-get update
 
-# Here we install a python coverage tool and an
-# https library that is out of date in the base image.
-
-RUN pip install coverage
-
-# update security libraries in the base image
-RUN pip install cffi --upgrade \
-    && pip install pyopenssl --upgrade \
-    && pip install ndg-httpsclient --upgrade \
-    && pip install pyasn1 --upgrade \
-    && pip install requests --upgrade \
-    && pip install 'requests[security]' --upgrade
-
-
-WORKDIR /kb/module
-
 RUN pip install --upgrade setuptools
 RUN pip install https://github.com/dib-lab/sourmash/archive/master.zip
 

--- a/lib/kb_sourmash/sourmash_utils/SourmashUtils.py
+++ b/lib/kb_sourmash/sourmash_utils/SourmashUtils.py
@@ -5,6 +5,7 @@ import subprocess
 import uuid
 import json
 import shutil
+import errno
 
 from KBaseReport.KBaseReportClient import KBaseReport
 from AssemblyUtil.AssemblyUtilClient import AssemblyUtil
@@ -179,7 +180,7 @@ class SourmashUtils:
             search_db = "/data/img_bact_sags.sbt.json"
         elif searchdb_label == "img_arch_sags":
             search_db = "/data/img_arch_sags.sbt.json"
-        elif search_db_label == "img_metag_metat_no_raw":
+        elif searchdb_label == "img_metag_metat_no_raw":
             search_db = "/data/metaG_metaT_no_raw.sbt.json"
         else:
             raise ValueError('search_db not valid')


### PR DESCRIPTION
With the sdkbase2 based dockerfile, coverage and the security and
requests libs aren't needed.

Fixed a couple of bugs ID'd by the linter.